### PR TITLE
Fix gallery loader script

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -16,28 +16,12 @@
 <script>
 (async function(){
   const grid = document.getElementById('galleryGrid');
+  if(!grid) return;
   try{
     const res = await fetch('content/gallery/index.json',{cache:'no-store'});
-    if(!res.ok){ grid.innerHTML='<p class="muted" style="text-align:center">No photos yet.</p>'; return; }
+    if(!res.ok) throw new Error('Failed to load gallery index');
     const idx = await res.json();
-    const items = await Promise.all(idx.files.map(f=>fetch('content/gallery/'+f).then(r=>r.json())));
-    grid.innerHTML = items.map(i=>`
-      <div class="gallery-item">
-        ${i.photo?`<img src="${i.photo}" alt="${i.title}" loading="lazy">`:''}
-        <div class="meta"><h4>${i.title}</h4><p>${i.description||''}</p></div>
-      </div>`).join('');
-  }catch{ grid.innerHTML='<p class="muted" style="text-align:center">No photos yet.</p>'; }
-})();
-</script>
-<script src="assets/js/app.js" defer></script>
-</body></html>
-<script>
-(async function(){
-  const grid = document.getElementById('galleryGrid');
-  try{
-    const res = await fetch('content/gallery/index.json',{cache:'no-store'});
-    const idx = await res.json();
-    const items = idx.items || [];
+    const items = Array.isArray(idx.items) ? idx.items : [];
     if(!items.length){
       grid.innerHTML = '<p class="muted" style="text-align:center">No photos yet.</p>';
       return;
@@ -53,4 +37,6 @@
   }
 })();
 </script>
+<script src="assets/js/app.js" defer></script>
+</body></html>
 


### PR DESCRIPTION
## Summary
- replace the duplicated gallery loader scripts with a single implementation that matches the current content structure
- add defensive checks so the gallery gracefully handles missing elements and failed fetches

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ed64b5c0c88322925068aa0e1036ce